### PR TITLE
Add API ingestion scripts for stations and journals from constellete.org

### DIFF
--- a/data-discovery-tool/api/constellete/fetch_journals.py
+++ b/data-discovery-tool/api/constellete/fetch_journals.py
@@ -1,0 +1,27 @@
+import requests
+import json
+import os
+
+API_BASE_URL = "https://api.constellete.org/v1"
+
+def fetch_journals():
+    url = f"{API_BASE_URL}/journals"
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching journals: {e}")
+        return []
+
+def save_to_file(data, filename="journals_raw.json"):
+    raw_path = os.path.join("data", "raw", filename)
+    os.makedirs(os.path.dirname(raw_path), exist_ok=True)
+    with open(raw_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    print(f"✅ Saved {len(data)} journals to {raw_path}")
+
+if __name__ == "__main__":
+    journals = fetch_journals()
+    if journals:
+        save_to_file(journals)

--- a/data-discovery-tool/api/constellete/fetch_stations.py
+++ b/data-discovery-tool/api/constellete/fetch_stations.py
@@ -1,0 +1,28 @@
+import requests
+import json
+import os
+
+# You might need to change this to the real URL
+API_BASE_URL = "https://api.constellete.org/v1"
+
+def fetch_field_stations():
+    url = f"{API_BASE_URL}/stations"
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching stations: {e}")
+        return []
+
+def save_to_file(data, filename="stations_raw.json"):
+    raw_path = os.path.join("data", "raw", filename)
+    os.makedirs(os.path.dirname(raw_path), exist_ok=True)
+    with open(raw_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    print(f"✅ Saved {len(data)} stations to {raw_path}")
+
+if __name__ == "__main__":
+    stations = fetch_field_stations()
+    if stations:
+        save_to_file(stations)


### PR DESCRIPTION
 Initial implementation of Tier 1 ingestion scripts that pull station and journal data from constellete.org and save to /data/raw.